### PR TITLE
Run and save meta data saving.

### DIFF
--- a/labcore/ddh5.py
+++ b/labcore/ddh5.py
@@ -80,14 +80,26 @@ def _save_dictionary(dict: Dict, filepath: str) -> None:
     with open(filepath, 'w') as f:
         json.dump(dict, f, indent=2, sort_keys=True)
 
+def _pickle_and_save(obj, filepath: str) -> None:
 
-def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **saving_dictionaries) -> None:
+    try:
+        with open(filepath, 'wb') as f:
+            pickle.dump(obj, f)
+    except TypeError as pickle_error:
+        print(f'Object could not be pickled: {pickle_error.args}')
+
+
+def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **extra_saving_items) -> None:
     """
     Iterates through a sweep, saving the data coming through it into a file called <name> at <data_dir> directory.
 
     :param sweep: Sweep object to iterate through.
-    :param data_dir: Directory of file location
-    :param name: name of the file
+    :param data_dir: Directory of file location.
+    :param name: Name of the file.
+    :param extra_saving_items: Kwargs for extra objects that should be saved. If the kwarg is a dictionary, the function
+        will try and save it as a JSON file. If the dictionary contains objects that are not JSON serializable it will
+        be pickled. Any other kind of object will be pickled too.
+
     """
     data_dict = _create_datadict_structure(sweep)
 
@@ -96,30 +108,39 @@ def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **saving_dictiona
 
         # Saving meta-data
         dir = writer.filepath.removesuffix(writer.filename)
-        for key, value in saving_dictionaries.items():
+        for key, value in extra_saving_items.items():
+            dictionary_dir = dir + '\\' + key + '.json'
             if isinstance(value, dict):
                 try:
-                    _save_dictionary(value, dir + '\\' + key + '.json')
-                except TypeError as e:
+                    _save_dictionary(value, dictionary_dir)
+                except TypeError as error:
+                    # Delete the file created by _save_dictionary. This file does not contain the complete dictionary.
+                    if os.path.isfile(dictionary_dir):
+                        os.remove(dictionary_dir)
+
                     converted = False # Flag to see if there has been a converted ndarray.
                     for k, v in value.items():
                         if isinstance(v, np.ndarray):
                             value[k] = v.tolist()
                             converted = True
-
                     if converted:
                         try:
                             _save_dictionary(value, dir + '\\' + key + '.json')
-                        except TypeError as error:
-                            print(f'{key} has not been able to be fully save to json: {error.args}')
+                        except TypeError as e:
+
+                            if os.path.isfile(dictionary_dir):
+                                os.remove(dictionary_dir)
+
+                            print(f'{key} has not been able to save to json: {e.args}.'
+                                  f' The item will be pickled instead.')
+                            _pickle_and_save(value, dir + '\\' + key + '.pickle')
                     else:
-                        print(f'{key} has not been able to be fully save to json: {e.args}')
+                        print(f'{key} has not been able to save to json: {error.args}.'
+                              f' The item will be pickled instead.')
+                        _pickle_and_save(value, dir + '\\' + key + '.pickle')
             else:
-                try:
-                    with open( dir + '\\' + key + '.pickle', 'wb') as f:
-                        pickle.dump(value,f)
-                except erorrisimo:
-                    print(f'{type(value)} is currently not supported for storage saving.')
+                _pickle_and_save(value, dir + '\\' + key + '.pickle')
+
 
         # Save data.
         for line in sweep:

--- a/labcore/ddh5.py
+++ b/labcore/ddh5.py
@@ -109,14 +109,15 @@ def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **extra_saving_it
         # Saving meta-data
         dir = writer.filepath.removesuffix(writer.filename)
         for key, value in extra_saving_items.items():
-            dictionary_dir = dir + '\\' + key + '.json'
+            pickle_directory = dir + '\\' + key + '.pickle'
             if isinstance(value, dict):
+                dictionary_directory = dir + '\\' + key + '.json'
                 try:
-                    _save_dictionary(value, dictionary_dir)
+                    _save_dictionary(value, dictionary_directory)
                 except TypeError as error:
                     # Delete the file created by _save_dictionary. This file does not contain the complete dictionary.
-                    if os.path.isfile(dictionary_dir):
-                        os.remove(dictionary_dir)
+                    if os.path.isfile(dictionary_directory):
+                        os.remove(dictionary_directory)
 
                     converted = False # Flag to see if there has been a converted ndarray.
                     for k, v in value.items():
@@ -125,21 +126,21 @@ def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **extra_saving_it
                             converted = True
                     if converted:
                         try:
-                            _save_dictionary(value, dir + '\\' + key + '.json')
+                            _save_dictionary(value, pickle_directory)
                         except TypeError as e:
 
-                            if os.path.isfile(dictionary_dir):
-                                os.remove(dictionary_dir)
+                            if os.path.isfile(dictionary_directory):
+                                os.remove(dictionary_directory)
 
                             print(f'{key} has not been able to save to json: {e.args}.'
                                   f' The item will be pickled instead.')
-                            _pickle_and_save(value, dir + '\\' + key + '.pickle')
+                            _pickle_and_save(value, pickle_directory)
                     else:
                         print(f'{key} has not been able to save to json: {error.args}.'
                               f' The item will be pickled instead.')
-                        _pickle_and_save(value, dir + '\\' + key + '.pickle')
+                        _pickle_and_save(value, pickle_directory)
             else:
-                _pickle_and_save(value, dir + '\\' + key + '.pickle')
+                _pickle_and_save(value, pickle_directory)
 
 
         # Save data.

--- a/labcore/ddh5.py
+++ b/labcore/ddh5.py
@@ -109,39 +109,38 @@ def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **extra_saving_it
         # Saving meta-data
         dir = writer.filepath.removesuffix(writer.filename)
         for key, value in extra_saving_items.items():
-            pickle_directory = os.path.join(dir, key + '.pickle')
+            pickle_path_file = os.path.join(dir, key + '.pickle')
             if isinstance(value, dict):
-                dictionary_directory = os.path.join(dir, key + '.json')
+                json_path_file = os.path.join(dir, key + '.json')
                 try:
-                    _save_dictionary(value, dictionary_directory)
+                    _save_dictionary(value, json_path_file)
                 except TypeError as error:
                     # Delete the file created by _save_dictionary. This file does not contain the complete dictionary.
-                    if os.path.isfile(dictionary_directory):
-                        os.remove(dictionary_directory)
+                    if os.path.isfile(json_path_file):
+                        os.remove(json_path_file)
 
-                    converted = False # Flag to see if there has been a converted ndarray.
+                    converted = False  # Flag to see if there has been a converted ndarray.
                     for k, v in value.items():
                         if isinstance(v, np.ndarray):
                             value[k] = v.tolist()
                             converted = True
                     if converted:
                         try:
-                            _save_dictionary(value, pickle_directory)
+                            _save_dictionary(value, json_path_file)
                         except TypeError as e:
 
-                            if os.path.isfile(dictionary_directory):
-                                os.remove(dictionary_directory)
+                            if os.path.isfile(json_path_file):
+                                os.remove(json_path_file)
 
                             print(f'{key} has not been able to save to json: {e.args}.'
                                   f' The item will be pickled instead.')
-                            _pickle_and_save(value, pickle_directory)
+                            _pickle_and_save(value, pickle_path_file)
                     else:
                         print(f'{key} has not been able to save to json: {error.args}.'
                               f' The item will be pickled instead.')
-                        _pickle_and_save(value, pickle_directory)
+                        _pickle_and_save(value, pickle_path_file)
             else:
-                _pickle_and_save(value, pickle_directory)
-
+                _pickle_and_save(value, pickle_path_file)
 
         # Save data.
         for line in sweep:

--- a/labcore/ddh5.py
+++ b/labcore/ddh5.py
@@ -109,9 +109,9 @@ def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **extra_saving_it
         # Saving meta-data
         dir = writer.filepath.removesuffix(writer.filename)
         for key, value in extra_saving_items.items():
-            pickle_directory = dir + '\\' + key + '.pickle'
+            pickle_directory = os.path.join(dir, key + '.pickle')
             if isinstance(value, dict):
-                dictionary_directory = dir + '\\' + key + '.json'
+                dictionary_directory = os.path.join(dir, key + '.json')
                 try:
                     _save_dictionary(value, dictionary_directory)
                 except TypeError as error:

--- a/labcore/ddh5.py
+++ b/labcore/ddh5.py
@@ -98,7 +98,7 @@ def run_and_save_sweep(sweep: Sweep, data_dir: str, name: str, **extra_saving_it
     :param name: Name of the file.
     :param extra_saving_items: Kwargs for extra objects that should be saved. If the kwarg is a dictionary, the function
         will try and save it as a JSON file. If the dictionary contains objects that are not JSON serializable it will
-        be pickled. Any other kind of object will be pickled too.
+        be pickled. Any other kind of object will be pickled too. The files will have their keys as names.
 
     """
     data_dict = _create_datadict_structure(sweep)


### PR DESCRIPTION
Added the ability to save meta-data with the run_and_save_sweep() function. The function accepts any kwargs and will try to save it. The names of the files are the keys of the kwargs.

If a kwarg is a dictionary, it will try to save it as a json file. If it fails and detects that an ndarray is present as one of its values, it will transform it into a list. After trying, if it still fails, the dictionary will be pickled and saved.

Any other object passed will be pickled and saved. If an object is passed that cannot be pickled, the function will print a warning saying that the item was not able to be saved, but it will still run and save the sweep.

A few things I would like to have feedback:

- The whole try and save as a dictionary, convert and try again might be a little bit too complicated and could be simplified if either we just save everything as a pickle, or try to save a json once instead of converting and trying again.
- When trying to save to JSON but it fails, a file is still created with missing data. I could not properly figure out what objects get saved and which ones don't when this happens, so to not save extra dead files I manually delete them.
- General code style.
